### PR TITLE
No escape inline syntaxes in list item

### DIFF
--- a/lib/Pod/Markdown.pm
+++ b/lib/Pod/Markdown.pm
@@ -136,7 +136,6 @@ sub command {
         $data->{Indent}--;
         $data->{searching} = '';
     } elsif ($command =~ m{item}xms) {
-        $paragraph = $parser->interpolate($paragraph, $line_num);
         $paragraph =~ s{^[ \t]* \* [ \t]*}{}xms;
 
         if ($data->{searching} eq 'listpara') {

--- a/t/misc.t
+++ b/t/misc.t
@@ -66,6 +66,7 @@ item
 
 - list
 - test
+- and _Italics_, __Bold__, `Code`, and [Links](${pod_prefix}Links) should work in list item
 
 # Links
 
@@ -205,6 +206,8 @@ item
 list
 
 =item * test
+
+=item * and I<Italics>, B<Bold>, C<Code>, and L<Links> should work in list item
 
 =back
 


### PR DESCRIPTION
POD allows formatting codes placed in `=item`, so

```
=over 4

=item A C<code>

=back
```

should be interpreted as:

```
- A `code`
```

This pull-req fixes over-escaping of these inline syntaxes.
