### PR TITLE
Code entries in headers

### DIFF
--- a/lib/Pod/Markdown.pm
+++ b/lib/Pod/Markdown.pm
@@ -111,7 +111,11 @@ sub command {
     if ($command =~ m{head(\d)}xms) {
         my $level = $1;
 
-        $paragraph = $parser->_escape($paragraph);
+        # escape markdown characters in text sequences except for inline code
+        $paragraph = join '', $parser->parse_text(
+            { -expand_text => '_escape_non_code' },
+            $paragraph, $line_num
+        )->raw_text;
         $paragraph = $parser->interpolate($paragraph, $line_num);
 
         # the headers never are indented

--- a/t/misc.t
+++ b/t/misc.t
@@ -46,6 +46,8 @@ __Nested `codes`__ work, too
 
 Inline `code _need not_ be escaped`.
 
+### Heading `code _need not_ be escaped, either`.
+
 __Nested `c*des` \\_should\\_ be escaped__ (but not code).
 
 non-breaking space: foo&nbsp;bar.
@@ -171,6 +173,8 @@ B<< Nested C<codes> >> work, too
 =head2 _Other_ *Characters* [Should](Be) `Escaped` in headers
 
 Inline C<< code _need not_ be escaped >>.
+
+=head3 Heading C<< code _need not_ be escaped, either >>.
 
 B<< Nested C<c*des> _should_ be escaped >> (but not code).
 


### PR DESCRIPTION
Hello

I use the code in my 3rd level headers.

These are subs' names and environment variables.

But they get escaped there although they are enclosed as the code: C<>.

Example is:

  https://github.com/petr999/Debug-Fork-Tmux

This patch seems to resolve my problem

Thank you.
