### PR TITLE
Recognize numbered list without dot.

### DIFF
--- a/lib/Pod/Markdown.pm
+++ b/lib/Pod/Markdown.pm
@@ -148,9 +148,9 @@ sub command {
         $data->{ListType} = '-'; # Default
         if($paragraph =~ m{^[ \t]* \* [ \t]*}xms) {
             $paragraph =~ s{^[ \t]* \* [ \t]*}{}xms;
-        } elsif($paragraph =~ m{^[ \t]* (\d+\.) [ \t]*}xms) {
-            $data->{ListType} = $1; # For numbered list only
-            $paragraph =~ s{^[ \t]* \d+\. [ \t]*}{}xms;
+        } elsif($paragraph =~ m{^[ \t]* (\d+)\.? [ \t]*}xms) {
+            $data->{ListType} = $1.'.'; # For numbered list only
+            $paragraph =~ s{^[ \t]* \d+\.? [ \t]*}{}xms;
         }
 
         if ($data->{searching} eq 'listpara') {

--- a/t/lists.t
+++ b/t/lists.t
@@ -63,6 +63,11 @@ __Note:__ Markdown does not support definition lists (word => text), just bullet
 
 1. B
 2. D
+
+## Ordered without dot
+
+1. B
+2. D
 EOMARKDOWN
 
 # check out Pod::IkiWiki (or something like that)...
@@ -171,6 +176,20 @@ Finally, this is also a list head.
 B
 
 =item 2.
+
+D
+
+=back
+
+=head2 Ordered without dot
+
+=over
+
+=item 1
+
+B
+
+=item 2
 
 D
 


### PR DESCRIPTION
`perldoc perlpodspec` says:

> (Pod processors must tolerate lines like "=item 1" as if they were "=item 1.", with the period.)

So, I adjusted regexp little.

Actually, `Pod::Elemental::Transformer::List` via `Dist::Zilla::Plugin::PodWeaver` produces such a numbered list without dot.
