### PR TITLE
eliminate extra blank line in verbatim blocks

### DIFF
--- a/lib/Pod/Markdown.pm
+++ b/lib/Pod/Markdown.pm
@@ -193,6 +193,9 @@ sub verbatim {
         $paragraph = join "\n", map { /^\t/ ? $_ : $indent . $_ } @lines;
     }
 
+    if($parser->{_PREVIOUS} eq 'verbatim' && $parser->_private->{Text}->[-1] =~ /[ \t]+$/) {
+        $paragraph = $parser->_unsave . "\n" . $paragraph;
+    }
     $parser->_save($paragraph);
 }
 

--- a/t/verbatim.t
+++ b/t/verbatim.t
@@ -47,6 +47,22 @@ to preserve the formatting:
 
     a little short, but valid
 
+# indented blank lines
+
+    one
+    two
+    
+    three
+    four
+
+# nonindented blank lines
+
+    one
+    two
+
+    three
+    four
+
 # THAT'S ENOUGH
 EOMARKDOWN
 
@@ -91,6 +107,22 @@ to preserve the formatting:
 =head1 1 space
 
  a little short, but valid
+
+=head1 indented blank lines
+
+ one
+ two
+ 
+ three
+ four
+
+=head1 nonindented blank lines
+
+ one
+ two
+
+ three
+ four
 
 =head1 THAT'S ENOUGH
 


### PR DESCRIPTION
I get extra lines in the markdown output when I include bllank lines in my verbatim blocks.  Example (using $ for EOL):

```
    line one$
    line two$
    $
    line three$
```

becomes

```
    line one$
    line two$
    $
$
    line three$
```

I don't see this extra line with other formatters.  Caveats:
1. the bug (if it is one) may actually be in Pod::Parser
2. The patch provided uses a private attribute _PREVIOUS and may not be kosher

but at least the test case should be useful if there is a better solution.
