### PR TITLE
Should not escape when target is link format or file format.

### DIFF
--- a/lib/Pod/Markdown.pm
+++ b/lib/Pod/Markdown.pm
@@ -213,9 +213,11 @@ sub _escape_and_interpolate {
 
 sub _escape_non_code {
     my ($parser, $text, $ptree) = @_;
-    $text = $parser->_escape($text)
-        unless $ptree->isa('Pod::InteriorSequence') && $ptree->cmd_name eq 'C';
-    return $text;
+
+    if ($ptree->isa('Pod::InteriorSequence') && $ptree->cmd_name =~ /\A[CFL]\z/) {
+        return $text;
+    }
+    return $parser->_escape($text);
 }
 
 sub textblock {

--- a/t/misc.t
+++ b/t/misc.t
@@ -46,6 +46,10 @@ __Nested `codes`__ work, too
 
 Inline `code _need not_ be escaped`.
 
+Inline [link_should_not_be_escaped](http://search.cpan.org/perldoc?link_should_not_be_escaped).
+
+Inline `filename_should_not_be_escaped`.
+
 ### Heading `code _need not_ be escaped, either`.
 
 __Nested `c*des` \\_should\\_ be escaped__ (but not code).
@@ -173,6 +177,10 @@ B<< Nested C<codes> >> work, too
 =head2 _Other_ *Characters* [Should](Be) `Escaped` in headers
 
 Inline C<< code _need not_ be escaped >>.
+
+Inline L<< link_should_not_be_escaped >>.
+
+Inline F<< filename_should_not_be_escaped >>.
 
 =head3 Heading C<< code _need not_ be escaped, either >>.
 


### PR DESCRIPTION
Now, content of F< ... > notation and L< ... > notation is escaped.

**e.g.**
F<.dot_file> => `.dot\_file`
L<foo_link> => [foo_link](http://search.cpan.org/perldoc?foo\_link)

I think, they should not be escaped.
So I fix it. Could you review and merge this?
