### PR TITLE
the 2.001 release broke tests in [ReadmeAnyFromPod]

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,9 @@ Revision history for Perl extension {{$dist->name}}
 
 {{$NEXT}}
 
+  - metadata and test added to look for incompatibilities with downstream
+    consumers
+
 2.001     2014-04-20T02:40:11Z
 
   - Use double-asterisk instead of double-underscore for bold Markdown.

--- a/dist.ini
+++ b/dist.ini
@@ -18,3 +18,8 @@ Git::Commit.allow_dirty = README.mkdn
 
 ; Verbatim tests have trailing whitespace (in pod and and heredocs).
 Test::EOL.trailing_whitespace = 0
+
+[Breaks]
+Dist::Zilla::Plugin::ReadmeAnyFromPod = <= 0.133360
+
+[Test::CheckBreaks]


### PR DESCRIPTION
So, record the breakage in metadata (Dist::Zilla::Plugin::ReadmeAnyFromPod up
to and including 0.133360 are broken by Pod::Markdown), and add a
(never-failing) test that will check this metadata and noisily tell the user
to update their plugin.
