### PR TITLE
support perldoc -o option

### DIFF
--- a/README.mkdn
+++ b/README.mkdn
@@ -4,7 +4,7 @@ Pod::Markdown - Convert POD to Markdown
 
 # VERSION
 
-version 2.002
+version 2.003
 
 # SYNOPSIS
 
@@ -215,9 +215,9 @@ progress on the request by the system.
 
 ## Source Code
 
-[https://github.com/rwstauner/Pod-Markdown](https://github.com/rwstauner/Pod-Markdown)
+[https://github.com/ambs/Pod-Markdown](https://github.com/ambs/Pod-Markdown)
 
-    git clone https://github.com/rwstauner/Pod-Markdown.git
+    git clone https://github.com/ambs/Pod-Markdown.git
 
 # AUTHORS
 

--- a/lib/Pod/Markdown.pm
+++ b/lib/Pod/Markdown.pm
@@ -201,10 +201,14 @@ sub _prepare_fragment_formats {
 # but the old Pod::Markdown never printed to a handle
 # so we don't want to start now.
 sub parse_from_file {
-  my ($self, $file) = @_;
+  my ($self, $file, $outfh) = @_;
   $self->output_string(\($self->{_as_markdown_}));
   $self->parse_file($file);
+
+  print $outfh $self->{_as_markdown_} if defined $outfh;
 }
+
+sub output_extension { 'md' }
 
 # Likewise, though Pod::Simple doesn't define this method at all.
 sub parse_from_filehandle { shift->parse_from_file(@_) }
@@ -212,6 +216,7 @@ sub parse_from_filehandle { shift->parse_from_file(@_) }
 =for Pod::Coverage
 parse_from_file
 parse_from_filehandle
+output_extension
 
 =cut
 


### PR DESCRIPTION
as discussed in #12 

It is a shame Pod::Markdown is outputting latin1 and not utf8, but then... for now is good enough :-)