### PR TITLE
add option to turn off URL escaping

### DIFF
--- a/t/links.t
+++ b/t/links.t
@@ -139,6 +139,10 @@ my @tests = (
   $p = {local_module_url_prefix => ''};
   test_link($p, q<Local::Foo::Bar>, qq^[Local::Foo::Bar](Local%3A%3AFoo%3A%3ABar)^,
     'local module with empty prefix');
+
+  $p = {local_module_url_prefix => 'http://foo/', escape_url => 0};
+  test_link($p, q<Local::Foo::Bar>, qq^[Local::Foo::Bar](http://foo/Local::Foo::Bar)^,
+    'local module with empty prefix');
 }
 
 # Most of these examples were internal links

--- a/t/new.t
+++ b/t/new.t
@@ -67,4 +67,8 @@ like warning { Pod::Markdown->new(unknown_arg => 1); },
 like warning { Pod::Markdown->new(encoding => 'oops'); },
   qr/encoding/, 'method that is not a rw attribute throws a warning';
 
+like warning { Pod::Markdown->new(local_module_url_prefix => '', escape_url => 0) },
+  qr/turning escape_url with an empty local_module_url_prefix is not recommended as relative URLs could be confused for IPv6 addresses/,
+  'use empty url prefix and do not escape url';
+
 done_testing;


### PR DESCRIPTION
I think escaping URLs is the more "correct" thing to do, however, it does make the resulting markdown less readable when viewing it in the terminal and thus defeats the purpose somewhat of markdown being equally readable as text or in a web browser.

I noted from the original ticket that this change was made to accommodate empty local prefix, which could make module names look like IPv6 addresses, so I've added a warning if both an empty prefix is specified and `url_escape(0)` is specified.